### PR TITLE
(remove unused variable in demo function)

### DIFF
--- a/geohash-demo.js
+++ b/geohash-demo.js
@@ -61,8 +61,7 @@ GeoHashBox.prototype.centerMap = function () {
 }
 	
 GeoHashBox.prototype.showNeighbors = function () {
-	var geohashPrefix = this.geohash.substr(0,this.geohash.length-1);
-	 
+
 	this.neighbors.top = new GeoHashBox(calculateAdjacent(this.geohash, 'top'));
 	this.neighbors.bottom = new GeoHashBox(calculateAdjacent(this.geohash, 'bottom'));
 	this.neighbors.right = new GeoHashBox(calculateAdjacent(this.geohash, 'right'));


### PR DESCRIPTION
not sure if this was intentional/didactic; but if it was maybe a comment would be in order (it _is_ helpful to have this as an illustrative example of how to shorten the hash string by one character, and i _can_ see how it would be helpful to have it here to implement a "zoom out by a much larger factor" type thing)
